### PR TITLE
docs: fix installation heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 3D portfolio created with React + Three.js
 
-## Instalation
+## Installation
 
 ```npm install```
 


### PR DESCRIPTION
## Summary
- fix typo in README installation section heading

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `module` is not defined)


------
https://chatgpt.com/codex/tasks/task_e_689600625bac832581f473e8254f7060